### PR TITLE
Egypt Prod (explo on) Legacy

### DIFF
--- a/Better Balanced Game.modinfo
+++ b/Better Balanced Game.modinfo
@@ -79,6 +79,8 @@
 					<Item>data/xml/constructibles_bbg.xml</Item>
 					<Item>data/xml/units_bbg.xml</Item>
 					<Item>data/xml/units_gameeffects_bbg.xml</Item>
+
+					<Item>data/xml/civ_gameeffects_bbg.xml</Item>
 				</UpdateDatabase>
 			</Actions>
 		</ActionGroup>

--- a/Localization/BBG_AntiquityPersistent_LOC.sql
+++ b/Localization/BBG_AntiquityPersistent_LOC.sql
@@ -132,3 +132,29 @@
     WHERE Tag = 'LOC_MEMENTO_BATTUTA_MERCHANTS_SADDLE_FUNCTIONAL_DESCRIPTION';
 --========================================================================================================================
 --========================================================================================================================
+
+
+
+
+
+
+
+
+
+
+
+
+
+--========================================================================================================================	
+-- Egypt
+-- Add new tradition usable in exploration and modern (after playing egypt in antiquity) for +2 prod to navigable rivers
+--========================================================================================================================
+	INSERT OR REPLACE INTO LocalizedText
+		(Tag,				Language,	Text)
+	VALUES	('LOC_NILE_LEGACY_DESCRIPTION', 'en_US',	'+2[icon:YIELD_PRODUCTION] Production on Navigable Rivers.');
+
+	INSERT OR REPLACE INTO LocalizedText
+		(Tag,				Language,	Text)
+	VALUES	('LOC_NILE_LEGACY_NAME',	'en_US',	'Nile Legacy');
+--========================================================================================================================
+--========================================================================================================================

--- a/data/BBG_AntiquityPersistent.sql
+++ b/data/BBG_AntiquityPersistent.sql
@@ -124,3 +124,51 @@
 	);
 --========================================================================================================================
 --========================================================================================================================
+
+
+
+
+
+
+
+--========================================================================================================================	
+-- Egypt
+-- Add new tradition usable in exploration and modern (after playing egypt in antiquity) for +2 prod to navigable rivers
+--========================================================================================================================
+	INSERT INTO Types
+		(Type,					Kind)
+	VALUES	('NODE_CIVIC_AQ_EGYPT_NILE_LEGACY',	'KIND_TREE_NODE');
+
+	INSERT INTO TYPEQUOTES
+		(Type,					Quote,					QuoteAuthor,					QuoteAudio)
+	VALUES	('NODE_CIVIC_AQ_EGYPT_NILE_LEGACY',	'LOC_CIVIC_AQ_EGYPT_NILE_LEGACY_QUOTE',	'LOC_CIVIC_AQ_EGYPT_NILE_LEGACY_QUOTE_AUTHOR',	'');
+	
+--	INSERT INTO ProgressionTreeNodes
+--		(ProgressionTreeNodeType,		ProgressionTree,	Cost,	Name,					IconString)
+--	VALUES	('NODE_CIVIC_AQ_EGYPT_NILE_LEGACY',	'TREE_CIVICS_AQ_EGYPT',	'9999',	'NODE_CIVIC_AQ_EGYPT_NILE_LEGACY_NAME',	'cult_egypt');
+	
+--	INSERT INTO ProgressionTreeNodeUnlocks
+--		(ProgressionTreeNodeType,		TargetKind,		TargetType,			UnlockDepth)
+--	VALUES	('NODE_CIVIC_AQ_EGYPT_NILE_LEGACY',	'KIND_TRADITION',	'TRADITION_NILE_LEGACY',	'1');
+	
+	INSERT INTO Types
+		(Type,				Kind)
+	VALUES	('TRADITION_NILE_LEGACY',	'KIND_TRADITION');
+
+	INSERT INTO TRADITIONS
+		(TraditionType,			Name,			Description,			TraitType,	AgeType)
+	VALUES	('TRADITION_NILE_LEGACY',	'LOC_NILE_LEGACY_NAME',	'LOC_NILE_LEGACY_DESCRIPTION',	'TRAIT_EGYPT',	'AGE_ANTIQUITY');
+
+	INSERT INTO TraditionModifiers
+		(TraditionType,			ModifierId)
+	VALUES	('TRADITION_NILE_LEGACY',	'NILE_LEGACY_MOD_PROD_BBG');
+
+	INSERT INTO ModifierStrings
+		(ModifierId,			Context,	Text)
+	VALUES	('NILE_LEGACY_MOD_PROD_BBG',	'Description',	'LOC_TRADITION_NILE_LEGACY_DESCRIPTION');
+
+	INSERT INTO Warehouse_YieldChanges
+		(ID,						Age,			YieldType,		YieldChange,	NavigableRiverInCity)
+	VALUES	('EgyptNileLegacyNavigableRiverProduction',	'AGE_ANTIQUITY',	'YIELD_PRODUCTION',	'2',		'TRUE');
+--========================================================================================================================
+--========================================================================================================================

--- a/data/xml/civ_gameeffects_bbg.xml
+++ b/data/xml/civ_gameeffects_bbg.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<GameEffects xmlns="GameEffects">
+	<!-- New BBG Egypt Legacy Tradition -->
+	<Modifier id="NILE_LEGACY_MOD_PROD_BBG" collection="COLLECTION_PLAYER_CITIES" effect="EFFECT_CITY_GRANT_WAREHOUSE_YIELD">
+		<Argument name="WarehouseYieldChange">EgyptNileLegacyNavigableRiverProduction</Argument>
+		<Argument name="Tooltip">LOC_TRADITION_NILE_LEGACY_DESCRIPTION</Argument>
+	</Modifier>
+</GameEffects>
+
+<!--
+<Database>
+	<Types>
+		<Row Type="TRADITION_NILE_LEGACY" Kind="KIND_TRADITION"/>
+	</Types>
+	<Traditions>
+		<Row TraditionType="TRADITION_NILE_LEGACY" Name="LOC_TRADITION_NILE_LEGACY_NAME" Description="LOC_TRADITION_NILE_LEGACY_DESCRIPTION" TraitType="TRAIT_EGYPT" AgeType="AGE_ANTIQUITY"/>
+	</Traditions>
+	<TraditionModifiers>
+		<Row TraditionType="TRADITION_NILE_LEGACY" ModifierId="NILE_LEGACY_MOD_PROD_BBG"/>
+	</TraditionModifiers>
+	<Warehouse_YieldChanges>
+		<Row ID="EgyptNileLegacyNavigableRiverProduction" Age="AGE_ANTIQUITY" YieldType="YIELD_PRODUCTION" YieldChange="2" NavigableRiverInCity="true"/>
+	</Warehouse_YieldChanges>
+</Database>
+-->


### PR DESCRIPTION
Added an 'unobtainable' tradition to egypt granting +2 prod on navigable rivers. It becomes available in exploration era onwards after having played egypt in antiquity.